### PR TITLE
Add docker build-step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build firmware
+
+on:
+  push:
+
+  pull_request:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build docker image
+        run: make lxr-docker-builder
+
+      - name: Build firmware
+        run: |
+          make firmware-docker
+          tar -czvf firmware.tar.gz firmware\ image/FIRMWARE.BIN
+
+      - name: Archive firmware
+        uses: actions/upload-artifact@v2
+        with:
+          name: Firmware binary
+          if-no-files-found: error
+          path: firmware.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 *.bin
 *.lss
 
+tools/bin/
+
 !firmware image/FIRMWARE.BIN
 
 #eclipse staging areas

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:trusty
+
+RUN mkdir installing \
+    && cd installing \
+    && apt-get update \
+    && apt-get install curl gcc-avr avr-libc lib32ncurses5 cpio build-essential make --yes \
+    && curl -OL https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/gcc-arm-none-eabi-4_8-2014q1-20140314-linux.tar.bz2
+
+WORKDIR installing
+
+RUN tar xvjf gcc-arm-none-eabi-4_8-2014q1-20140314-linux.tar.bz2 \
+    && mv gcc-arm-none-eabi-4_8-2014q1 /opt/ARM \
+    && rm gcc-arm-none-eabi-4_8-2014q1-20140314-linux.tar.bz2
+
+ENV PATH="/opt/ARM/bin:${PATH}"
+
+WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ clean:
 .PHONY: firmware
 firmware: $(IMAGE)
 
+.PHONY: lxr-docker-builder
+lxr-docker-builder:
+	docker build -t lxr-docker-builder .
+
+.PHONY: firmware-docker
+firmware-docker: lxr-docker-builder
+	docker run -v ${PWD}:/app lxr-docker-builder:latest make firmware
+
 $(IMAGE): $(ARM_BINARY) $(AVR_BINARY) $(FIB)
 	@echo "Building final firmware image $@..."
 	$(AT)$(FIB) $(ARM_BINARY) $(AVR_BINARY) "$@"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Please note that there are libraries from ST and ARM used in the mainboard code 
 
 Many Thanks to user Rudeog who contributet a lot of bugfixes and features for version 0.26 and 0.33 as well as Patrick Dowling for the Makefiles for the Linux build system!
 
+To build the firmware in docker follow these instructions:
+----------------------------------------------------------------
+You will need:
+- docker
+
+```sh
+make firmware-docker
+```
 
 
 Instructions for building on Linux using the provided makefiles:


### PR DESCRIPTION
Hey, 

Was planning to start looking at some modifications I had in mind and started out by adding a Github Actions build step and a way to build the firmware in a docker. Maybe this could be useful to upstream.